### PR TITLE
Create a store for the binding spell to keep track of which entities are bound to each other.

### DIFF
--- a/src/main/java/com/tzaranthony/spellbook/core/blocks/containsBE/Alter.java
+++ b/src/main/java/com/tzaranthony/spellbook/core/blocks/containsBE/Alter.java
@@ -12,6 +12,7 @@ import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -25,6 +26,7 @@ import net.minecraft.world.phys.BlockHitResult;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.Optional;
 
 public class Alter extends TickingBEBlock {
     public Alter(Properties properties) {
@@ -43,7 +45,7 @@ public class Alter extends TickingBEBlock {
             if (itemstack.getItem() instanceof SpellBookNovice && abe.checkMultiBlock()) {
                 level.playSound((Player) null, pos.getX(), pos.getY(), pos.getZ(), SoundEvents.ZOMBIE_VILLAGER_CURE, SoundSource.BLOCKS, 0.5F, 1.0F);
                 abe.startCrafting();
-                for(int i = 0; i < 8; ++i) {
+                for (int i = 0; i < 8; ++i) {
                     double d0 = (double) pos.getX() + level.random.nextDouble();
                     double d1 = (double) pos.above().getY() + level.random.nextDouble();
                     double d2 = (double) pos.getZ() + level.random.nextDouble();
@@ -54,7 +56,8 @@ public class Alter extends TickingBEBlock {
                         new AABB((double) (pos.getX() - 10), (double) (pos.getY() - 10), (double) (pos.getZ() - 10), (double) (pos.getX() + 10), (double) (pos.getY() + 10), (double) (pos.getZ() + 10)));
                 boolean addedMobs = false;
                 for (Mob mob : mobs) {
-                    if (Binding.isBound(mob) && Binding.isBoundBy(mob) == player) {
+                    Optional<Entity> boundedBy = Binding.isBoundBy(mob);
+                    if (Binding.isBound(mob) && boundedBy.isPresent() && boundedBy.get() == player) {
                         abe.addMob(mob);
                         addedMobs = true;
                     }

--- a/src/main/java/com/tzaranthony/spellbook/core/spells/Binding.java
+++ b/src/main/java/com/tzaranthony/spellbook/core/spells/Binding.java
@@ -12,7 +12,6 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleTypes;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.Mth;
@@ -28,10 +27,12 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
-import javax.annotation.Nullable;
-import java.util.UUID;
+import java.util.*;
 
-public class Binding extends ProjectileSpell{
+import static java.util.stream.Collectors.toSet;
+
+// TODO: Remove references to the tags in favor of the BindingUtil.
+public class Binding extends ProjectileSpell {
     protected static String BOUND_TO_ID = "SBEIDSoulBoundTo:";
     protected static String BOUND_TO_UUID = "SBUUIDSoulBoundTo:";
     protected static String IS_BOUND = "SBIsSoulBound";
@@ -48,7 +49,7 @@ public class Binding extends ProjectileSpell{
 
     @Override
     public boolean perform_spell(Entity usr, Entity tgt) {
-        if (tgt instanceof Mob target && !(tgt.getType().is(SBEntityTags.PACIFY_IMMUNE)) && !(tgt instanceof Player)) {
+        if (tgt instanceof Mob target && !(tgt.getType().is(SBEntityTags.PACIFY_IMMUNE))) {
             if (!isBound(target) && !target.isLeashed()) {
                 bindEntity(usr, target);
             }
@@ -60,7 +61,7 @@ public class Binding extends ProjectileSpell{
 
     @Override
     public void playCustomSound(Level level, double x, double y, double z) {
-        level.playSound((Player) null, x, y, z, SoundEvents.GLOW_INK_SAC_USE, SoundSource.PLAYERS, 1.0F, 1.0F);
+        level.playSound(null, x, y, z, SoundEvents.GLOW_INK_SAC_USE, SoundSource.PLAYERS, 1.0F, 1.0F);
     }
 
     //TODO: create a knot like entity to bind to an alter
@@ -68,64 +69,40 @@ public class Binding extends ProjectileSpell{
         if (bound.isPassenger()) {
             bound.stopRiding();
         }
-        String tagBind = IS_BOUND;
-        String tagUUID = BOUND_TO_UUID + binder.getStringUUID();
-        String tagEID = BOUND_TO_ID + binder.getId();
-        bound.addTag(tagBind);
-        bound.addTag(tagUUID);
-        bound.addTag(tagEID);
 
         if (!bound.level.isClientSide()) {
             SBPackets.sendToAllPlayers(new SoulBindS2CPacket(bound.getId(), IS_BOUND, BOUND_TO_UUID + binder.getStringUUID(), BOUND_TO_ID + binder.getId()));
         }
+
+        BindingStore.addBinding(binder, bound);
     }
 
     public static boolean isBound(LivingEntity bound) {
-        return bound.getTags().contains(BOUND_TO_ID);
+        return !BindingStore.boundEntities(bound).isEmpty() || !BindingStore.playersBoundTo(bound).isEmpty();
     }
 
-    @Nullable
-    public static Entity isBoundBy(LivingEntity bound) {
-        if (!isBound(bound)) {
-            return null;
-        }
-        if (bound.level.isClientSide()) {
-            for (String str : bound.getTags()) {
-                if (str.contains(BOUND_TO_UUID)) {
-                    return bound.level.getPlayerByUUID(UUID.fromString(str.split(":", 2)[1]));
-                } else if (str.contains(BOUND_TO_ID)) {
-                    return bound.level.getEntity(Integer.getInteger(str.split(":", 2)[1]));
-                }
-            }
-        } else {
-            ServerLevel sLevel = (ServerLevel) bound.level;
-            for (String str : bound.getTags()) {
-                if (str.contains(BOUND_TO_UUID)) {
-                    return sLevel.getEntity(UUID.fromString(str.split(":", 2)[1]));
-                }
-            }
-        }
-        return null;
+    public static Optional<Entity> isBoundBy(LivingEntity bound) {
+        return BindingStore.playersBoundTo(bound).stream().findFirst();
     }
 
     public static void unbindEntity(LivingEntity bound) {
-        bound.removeTag(IS_BOUND);
-        for (String str : bound.getTags()) {
-            if (str.contains(BOUND_TO_UUID) || str.contains(BOUND_TO_ID)) {
-                bound.removeTag(str);
-            }
-        }
+        BindingStore.removeBinding(bound);
     }
 
     public static void tickSoulBind(LivingEntity le) {
         if (le instanceof Mob bound) {
-            Entity binder = isBoundBy(bound);
+            Optional<Entity> maybeBinder = isBoundBy(bound);
+            if (maybeBinder.isEmpty()) {
+                return;
+            }
+            Entity binder = maybeBinder.get();
 
             if (!bound.level.isClientSide()) {
+                // TODO(TzarAnthony): Not sure what this does, but it probably needs to change now.
                 SBPackets.sendToAllPlayers(new SoulBindS2CPacket(bound.getId(), IS_BOUND, BOUND_TO_UUID + binder.getStringUUID(), BOUND_TO_ID + binder.getId()));
             }
 
-            if (binder != null && binder.level == bound.level) {
+            if (binder.level == bound.level) {
                 bound.restrictTo(binder.blockPosition(), 5);
                 float f = bound.distanceTo(binder);
                 if (bound instanceof TamableAnimal && ((TamableAnimal) bound).isInSittingPose()) {
@@ -139,14 +116,15 @@ public class Binding extends ProjectileSpell{
                     unbindEntity(bound);
                     bound.goalSelector.disableControlFlag(Goal.Flag.MOVE);
                 } else if (f > 6.0F) {
-                    double d0 = (binder.getX() - bound.getX()) / (double)f;
-                    double d1 = (binder.getY() - bound.getY()) / (double)f;
-                    double d2 = (binder.getZ() - bound.getZ()) / (double)f;
+                    double d0 = (binder.getX() - bound.getX()) / (double) f;
+                    double d1 = (binder.getY() - bound.getY()) / (double) f;
+                    double d2 = (binder.getZ() - bound.getZ()) / (double) f;
                     bound.setDeltaMovement(bound.getDeltaMovement().add(Math.copySign(d0 * d0 * 0.4D, d0), Math.copySign(d1 * d1 * 0.4D, d1), Math.copySign(d2 * d2 * 0.4D, d2)));
                 } else {
                     bound.goalSelector.enableControlFlag(Goal.Flag.MOVE);
-                    float f1 = 2.0F;
-                    Vec3 vec3 = (new Vec3(binder.getX() - bound.getX(), binder.getY() - bound.getY(), binder.getZ() - bound.getZ())).normalize().scale((double)Math.max(f - 2.0F, 0.0F));
+                    // TODO(TzarAnthony): Determine if the following line exists for a reason. I know some of the code here is half-finished. Please advise if this unused variable can be removed.
+//                    float f1 = 2.0F;
+                    Vec3 vec3 = (new Vec3(binder.getX() - bound.getX(), binder.getY() - bound.getY(), binder.getZ() - bound.getZ())).normalize().scale(Math.max(f - 2.0F, 0.0F));
                     bound.getNavigation().moveTo(bound.getX() + vec3.x, bound.getY() + vec3.y, bound.getZ() + vec3.z, 1.0D);
                 }
             }
@@ -157,17 +135,17 @@ public class Binding extends ProjectileSpell{
     public static void renderSoulBind(Mob bound, float pTick, PoseStack pose, MultiBufferSource buff, LivingEntity binder) {
         pose.pushPose();
         Vec3 vec3 = binder.getRopeHoldPosition(pTick);
-        double d0 = (double)(Mth.lerp(pTick, bound.yBodyRot, bound.yBodyRotO) * ((float)Math.PI / 180F)) + (Math.PI / 2D);
+        double d0 = (double) (Mth.lerp(pTick, bound.yBodyRot, bound.yBodyRotO) * ((float) Math.PI / 180F)) + (Math.PI / 2D);
         Vec3 vec31 = bound.getLeashOffset();
         double d1 = Math.cos(d0) * vec31.z + Math.sin(d0) * vec31.x;
         double d2 = Math.sin(d0) * vec31.z - Math.cos(d0) * vec31.x;
-        double d3 = Mth.lerp((double)pTick, bound.xo, bound.getX()) + d1;
-        double d4 = Mth.lerp((double)pTick, bound.yo, bound.getY()) + vec31.y;
-        double d5 = Mth.lerp((double)pTick, bound.zo, bound.getZ()) + d2;
+        double d3 = Mth.lerp(pTick, bound.xo, bound.getX()) + d1;
+        double d4 = Mth.lerp(pTick, bound.yo, bound.getY()) + vec31.y;
+        double d5 = Mth.lerp(pTick, bound.zo, bound.getZ()) + d2;
         pose.translate(d1, vec31.y, d2);
-        float f = (float)(vec3.x - d3);
-        float f1 = (float)(vec3.y - d4);
-        float f2 = (float)(vec3.z - d5);
+        float f = (float) (vec3.x - d3);
+        float f1 = (float) (vec3.y - d4);
+        float f2 = (float) (vec3.z - d5);
         float f3 = 0.025F;
         VertexConsumer vertexconsumer = buff.getBuffer(RenderType.leash());
         Matrix4f matrix4f = pose.last().pose();
@@ -180,10 +158,10 @@ public class Binding extends ProjectileSpell{
         int j = getBlockLightLevel(binder, blockpos1);
         int k = bound.level.getBrightness(LightLayer.SKY, blockpos);
         int l = bound.level.getBrightness(LightLayer.SKY, blockpos1);
-        for(int i1 = 0; i1 <= 24; ++i1) {
+        for (int i1 = 0; i1 <= 24; ++i1) {
             addVertexPair(vertexconsumer, matrix4f, f, f1, f2, i, j, k, l, f3, f3, f5, f6, i1, false);
         }
-        for(int j1 = 24; j1 >= 0; --j1) {
+        for (int j1 = 24; j1 >= 0; --j1) {
             addVertexPair(vertexconsumer, matrix4f, f, f1, f2, i, j, k, l, f3, 0.0F, f5, f6, j1, true);
         }
         pose.popPose();
@@ -197,17 +175,109 @@ public class Binding extends ProjectileSpell{
     @OnlyIn(Dist.CLIENT)
     private static void addVertexPair(VertexConsumer consumer, Matrix4f m4, float x, float y, float z, int light, int light1, int light2, int light3, float xthicc, float ythicc, float dz, float dx, int segment, boolean colorSelector) {
         float f = (float) segment / 24.0F;
-        int i = (int)Mth.lerp(f, (float) light, (float) light1);
-        int j = (int)Mth.lerp(f, (float) light2, (float) light3);
+        int i = (int) Mth.lerp(f, (float) light, (float) light1);
+        int j = (int) Mth.lerp(f, (float) light2, (float) light3);
         int k = LightTexture.pack(i, j);
         float f1 = segment % 2 == (colorSelector ? 1 : 0) ? 0.7F : 1.0F;
-        float f2 = (180.0F/255.0F) * f1;
-        float f3 = (60.0F/255.0F) * f1;
-        float f4 = (200.0F/255.0F) * f1;
+        float f2 = (180.0F / 255.0F) * f1;
+        float f3 = (60.0F / 255.0F) * f1;
+        float f4 = (200.0F / 255.0F) * f1;
         float f5 = x * f;
         float f6 = y > 0.0F ? y * f * f : y - y * (1.0F - f) * (1.0F - f);
         float f7 = z * f;
         consumer.vertex(m4, f5 - dz, f6 + ythicc, f7 + dx).color(f2, f3, f4, 1.0F).uv2(k).endVertex();
         consumer.vertex(m4, f5 + dz, f6 + xthicc - ythicc, f7 - dx).color(f2, f3, f4, 1.0F).uv2(k).endVertex();
+    }
+
+    /**
+     * Binding storage for the {@link Binding} spell.
+     */
+    private static class BindingStore {
+        private static final Map<UUID, Set<UUID>> playerBindings = new HashMap<>();
+        private static final Map<UUID, Set<UUID>> entityBindings = new HashMap<>();
+        private static final Map<UUID, Entity> entities = new HashMap<>();
+
+        /**
+         * Adds a binding to the player {@link Entity} for the entity.
+         *
+         * @param player the player to bind the entity.
+         * @param entity the entity to bind to the player.
+         */
+        public static void addBinding(Entity player, Entity entity) {
+            if (isBindable(entity)) {
+                entities.put(player.getUUID(), player);
+                entities.put(entity.getUUID(), entity);
+                bindPlayerToEntity(player.getUUID(), entity.getUUID());
+                bindEntityToPlayer(player.getUUID(), entity.getUUID());
+            }
+        }
+
+        private static boolean isBindable(Entity entity) {
+            // Players should probably not be bindable.
+            if (entity instanceof Player) {
+                return false;
+            }
+            return entity instanceof LivingEntity;
+        }
+
+        private static void bindEntityToPlayer(UUID playerUUID, UUID entityUUID) {
+            if (playerBindings.containsKey(playerUUID)) {
+                playerBindings.get(playerUUID).add(entityUUID);
+                return;
+            }
+            playerBindings.put(playerUUID, new HashSet<>(List.of(new UUID[]{entityUUID})));
+        }
+
+        private static void bindPlayerToEntity(UUID playerUUID, UUID entityUUID) {
+            if (entityBindings.containsKey(entityUUID)) {
+                entityBindings.get(entityUUID).add(playerUUID);
+                return;
+            }
+            entityBindings.put(entityUUID, new HashSet<>(List.of(new UUID[]{playerUUID})));
+        }
+
+        /**
+         * Removes all bindings from all player {@link Entity Entities} for the specified entity.
+         *
+         * @param entity the entity to remove the binding for.
+         */
+        public static void removeBinding(Entity entity) {
+            UUID entityUUID = entity.getUUID();
+            Set<UUID> boundPlayers = entityBindings.get(entityUUID);
+            for (UUID playerUUID : boundPlayers) {
+                if (playerBindings.containsKey(playerUUID)) {
+                    playerBindings.get(playerUUID).remove(entityUUID);
+                }
+            }
+            entityBindings.remove(entityUUID);
+        }
+
+        /**
+         * Gets all the players bound to an entity.
+         *
+         * @param entity the {@link Entity} to get the bound players.
+         * @return a set of all player {@link Entity Entities} bound to the entity.
+         */
+        public static Set<Entity> playersBoundTo(Entity entity) {
+            UUID entityUUID = entity.getUUID();
+            if (entityBindings.containsKey(entityUUID)) {
+                return entityBindings.get(entityUUID).stream().map(entities::get).collect(toSet());
+            }
+            return new HashSet<>();
+        }
+
+        /**
+         * Gets all the bound {@link Entity Entities} to the player.
+         *
+         * @param player the player {@link Entity} to get the entities that are bound to it.
+         * @return the set of all {@link Entity Entities} bound to the player
+         */
+        public static Set<Entity> boundEntities(Entity player) {
+            UUID playerUUID = player.getUUID();
+            if (playerBindings.containsKey(playerUUID)) {
+                return playerBindings.get(playerUUID).stream().map(entities::get).collect(toSet());
+            }
+            return new HashSet<>();
+        }
     }
 }

--- a/src/main/java/com/tzaranthony/spellbook/core/spells/Binding.java
+++ b/src/main/java/com/tzaranthony/spellbook/core/spells/Binding.java
@@ -45,6 +45,7 @@ public class Binding extends ProjectileSpell {
     public void addSpellDataToProjectile(MagicProjectile magic) {
         magic.setSpell(this.getId());
         magic.setParticle(ParticleTypes.HEART);
+        magic.setLifetime(15);
     }
 
     @Override
@@ -112,7 +113,7 @@ public class Binding extends ProjectileSpell {
                     return;
                 }
 
-                if (f > 15.0F) {
+                if (f > 20.0F) {
                     unbindEntity(bound);
                     bound.goalSelector.disableControlFlag(Goal.Flag.MOVE);
                 } else if (f > 6.0F) {
@@ -122,8 +123,6 @@ public class Binding extends ProjectileSpell {
                     bound.setDeltaMovement(bound.getDeltaMovement().add(Math.copySign(d0 * d0 * 0.4D, d0), Math.copySign(d1 * d1 * 0.4D, d1), Math.copySign(d2 * d2 * 0.4D, d2)));
                 } else {
                     bound.goalSelector.enableControlFlag(Goal.Flag.MOVE);
-                    // TODO(TzarAnthony): Determine if the following line exists for a reason. I know some of the code here is half-finished. Please advise if this unused variable can be removed.
-//                    float f1 = 2.0F;
                     Vec3 vec3 = (new Vec3(binder.getX() - bound.getX(), binder.getY() - bound.getY(), binder.getZ() - bound.getZ())).normalize().scale(Math.max(f - 2.0F, 0.0F));
                     bound.getNavigation().moveTo(bound.getX() + vec3.x, bound.getY() + vec3.y, bound.getZ() + vec3.z, 1.0D);
                 }
@@ -191,6 +190,8 @@ public class Binding extends ProjectileSpell {
 
     /**
      * Binding storage for the {@link Binding} spell.
+     * <p>
+     * TODO(tim117): Store data somehow so that it persists.
      */
     private static class BindingStore {
         private static final Map<UUID, Set<UUID>> playerBindings = new HashMap<>();

--- a/src/main/java/com/tzaranthony/spellbook/core/util/events/SBClientEvents.java
+++ b/src/main/java/com/tzaranthony/spellbook/core/util/events/SBClientEvents.java
@@ -12,6 +12,8 @@ import net.minecraftforge.client.event.RenderLivingEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
+import java.util.Optional;
+
 
 @OnlyIn(Dist.CLIENT)
 @Mod.EventBusSubscriber(modid = SpellBook.MOD_ID, value = Dist.CLIENT)
@@ -21,8 +23,8 @@ public class SBClientEvents {
     public void onPostRenderEntity(RenderLivingEvent.Post event) {
         LivingEntity le = event.getEntity();
         if (Binding.isBound(le) && le instanceof Mob bound) {
-            Entity owner = Binding.isBoundBy(le);
-            if (owner instanceof LivingEntity leOwner) {
+            Optional<Entity> owner = Binding.isBoundBy(le);
+            if (owner.isPresent() && owner.get() instanceof LivingEntity leOwner) {
                 double d0 = Mth.lerp(event.getPartialTick(), le.xOld, le.getX());
                 double d1 = Mth.lerp(event.getPartialTick(), le.yOld, le.getY());
                 double d2 = Mth.lerp(event.getPartialTick(), le.zOld, le.getZ());

--- a/src/main/java/com/tzaranthony/spellbook/core/util/events/SBClientEvents.java
+++ b/src/main/java/com/tzaranthony/spellbook/core/util/events/SBClientEvents.java
@@ -20,9 +20,10 @@ import java.util.Optional;
 public class SBClientEvents {
     @SubscribeEvent
     @OnlyIn(Dist.CLIENT)
-    public void onPostRenderEntity(RenderLivingEvent.Post event) {
+    public static void onPostRenderEntity(RenderLivingEvent.Post event) {
         LivingEntity le = event.getEntity();
         if (Binding.isBound(le) && le instanceof Mob bound) {
+            // TODO(TzarAnthony): Fix this rendering.
             Optional<Entity> owner = Binding.isBoundBy(le);
             if (owner.isPresent() && owner.get() instanceof LivingEntity leOwner) {
                 double d0 = Mth.lerp(event.getPartialTick(), le.xOld, le.getX());

--- a/src/main/java/com/tzaranthony/spellbook/core/util/events/SBServerEvents.java
+++ b/src/main/java/com/tzaranthony/spellbook/core/util/events/SBServerEvents.java
@@ -15,6 +15,7 @@ public class SBServerEvents {
     @SubscribeEvent
     //TODO: move the modifiers to here instead of the items
     static void onBreakEvent(BlockEvent.BreakEvent event) {
+        System.out.println("Just broke a block...");
 //        ItemStack stack = event.getPlayer().getMainHandItem();
 //        if (stack.getItem() instanceof MiningModeTool mmItem && !event.getPlayer().level.isClientSide()) {
 //            ServerPlayer player = (ServerPlayer) event.getPlayer();

--- a/src/main/java/com/tzaranthony/spellbook/core/util/events/SBServerEvents.java
+++ b/src/main/java/com/tzaranthony/spellbook/core/util/events/SBServerEvents.java
@@ -14,7 +14,7 @@ import net.minecraftforge.fml.common.Mod;
 public class SBServerEvents {
     @SubscribeEvent
     //TODO: move the modifiers to here instead of the items
-    static void onBreakEvent(BlockEvent.BreakEvent event) {
+    public static void onBreakEvent(BlockEvent.BreakEvent event) {
         System.out.println("Just broke a block...");
 //        ItemStack stack = event.getPlayer().getMainHandItem();
 //        if (stack.getItem() instanceof MiningModeTool mmItem && !event.getPlayer().level.isClientSide()) {
@@ -27,7 +27,7 @@ public class SBServerEvents {
 
 
     @SubscribeEvent
-    public void onInteractWithEntity(PlayerInteractEvent.EntityInteract event) {
+    public static void onInteractWithEntity(PlayerInteractEvent.EntityInteract event) {
         if (event.getTarget() instanceof LivingEntity le) {
             if (!event.getEntity().isShiftKeyDown() && Binding.isBound(le)) {
                 Binding.unbindEntity(le);
@@ -38,7 +38,7 @@ public class SBServerEvents {
     }
 
     @SubscribeEvent
-    public void onLivingUpdateEvent(LivingEvent.LivingUpdateEvent event) {
+    public static void onLivingUpdateEvent(LivingEvent.LivingUpdateEvent event) {
         LivingEntity le = event.getEntityLiving();
         if (Binding.isBound(le)) {
             Binding.tickSoulBind(le);


### PR DESCRIPTION
The binding spell needs to know which entities are bound to each other in events. The current implementation of using tags is not working due to the events not passing the necessary tag information with the entities that are being tagged. In order to do this we need to hold state of the entities that are currently bound in a static class. Utility methods are exposed for interacting with the spell.

TODO(@TzarAnthony): This change is only Java ready. There may be some Minecraft specific nuances that I am not fully aware of. Please review thuroughly and let me know what areas need more guard conditions to ensure only the right entities or other boundaries are not being crossed.